### PR TITLE
Rename project to 'orc'

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -5,7 +5,7 @@
 domain: k-orc.cloud
 layout:
 - go.kubebuilder.io/v4
-projectName: openstack-resource-controller
+projectName: orc
 repo: github.com/gophercloud/openstack-resource-controller
 resources:
 - api:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: openstack-resource-controller-system
+namespace: orc-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: openstack-resource-controller-
+namePrefix: orc-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/name: deployment
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
   namespace: system

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: metrics-reader
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: metrics-reader
 rules:

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: proxy-role
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: proxy-role
 rules:

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: proxy-rolebinding
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: proxy-rolebinding
 roleRef:

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: service
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: role
     app.kubernetes.io/instance: leader-election-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: rolebinding
     app.kubernetes.io/instance: leader-election-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-rolebinding
 roleRef:

--- a/config/rbac/openstackcloud_editor_role.yaml
+++ b/config/rbac/openstackcloud_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstackcloud-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstackcloud-editor-role
 rules:

--- a/config/rbac/openstackcloud_viewer_role.yaml
+++ b/config/rbac/openstackcloud_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstackcloud-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstackcloud-viewer-role
 rules:

--- a/config/rbac/openstackflavor_editor_role.yaml
+++ b/config/rbac/openstackflavor_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstackflavor-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstackflavor-editor-role
 rules:

--- a/config/rbac/openstackflavor_viewer_role.yaml
+++ b/config/rbac/openstackflavor_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstackflavor-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstackflavor-viewer-role
 rules:

--- a/config/rbac/openstackfloatingip_editor_role.yaml
+++ b/config/rbac/openstackfloatingip_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstackfloatingip-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstackfloatingip-editor-role
 rules:

--- a/config/rbac/openstackfloatingip_viewer_role.yaml
+++ b/config/rbac/openstackfloatingip_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstackfloatingip-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstackfloatingip-viewer-role
 rules:

--- a/config/rbac/openstackimage_editor_role.yaml
+++ b/config/rbac/openstackimage_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstackimage-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstackimage-editor-role
 rules:

--- a/config/rbac/openstackimage_viewer_role.yaml
+++ b/config/rbac/openstackimage_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstackimage-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstackimage-viewer-role
 rules:

--- a/config/rbac/openstacknetwork_editor_role.yaml
+++ b/config/rbac/openstacknetwork_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstacknetwork-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstacknetwork-editor-role
 rules:

--- a/config/rbac/openstacknetwork_viewer_role.yaml
+++ b/config/rbac/openstacknetwork_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstacknetwork-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstacknetwork-viewer-role
 rules:

--- a/config/rbac/openstacksecuritygroup_editor_role.yaml
+++ b/config/rbac/openstacksecuritygroup_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstacksecuritygroup-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstacksecuritygroup-editor-role
 rules:

--- a/config/rbac/openstacksecuritygroup_viewer_role.yaml
+++ b/config/rbac/openstacksecuritygroup_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstacksecuritygroup-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstacksecuritygroup-viewer-role
 rules:

--- a/config/rbac/openstacksecuritygrouprule_editor_role.yaml
+++ b/config/rbac/openstacksecuritygrouprule_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstacksecuritygrouprule-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstacksecuritygrouprule-editor-role
 rules:

--- a/config/rbac/openstacksecuritygrouprule_viewer_role.yaml
+++ b/config/rbac/openstacksecuritygrouprule_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstacksecuritygrouprule-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstacksecuritygrouprule-viewer-role
 rules:

--- a/config/rbac/openstackserver_editor_role.yaml
+++ b/config/rbac/openstackserver_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstackserver-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstackserver-editor-role
 rules:

--- a/config/rbac/openstackserver_viewer_role.yaml
+++ b/config/rbac/openstackserver_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstackserver-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstackserver-viewer-role
 rules:

--- a/config/rbac/openstacksubnet_editor_role.yaml
+++ b/config/rbac/openstacksubnet_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstacksubnet-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstacksubnet-editor-role
 rules:

--- a/config/rbac/openstacksubnet_viewer_role.yaml
+++ b/config/rbac/openstacksubnet_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: openstacksubnet-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: openstacksubnet-viewer-role
 rules:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: manager-rolebinding
 roleRef:

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: serviceaccount
     app.kubernetes.io/instance: controller-manager-sa
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: openstack-resource-controller
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/config/samples/openstack_v1alpha1_openstackcloud.yaml
+++ b/config/samples/openstack_v1alpha1_openstackcloud.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstackcloud
     app.kubernetes.io/instance: openstackcloud-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: osp1
 spec:
   cloud: openstack # REPLACE with the name of the target cloud in clouds.yaml

--- a/config/samples/openstack_v1alpha1_openstackflavor.yaml
+++ b/config/samples/openstack_v1alpha1_openstackflavor.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstackflavor
     app.kubernetes.io/instance: openstackflavor-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: small
 spec:
   cloud: osp1

--- a/config/samples/openstack_v1alpha1_openstackfloatingip.yaml
+++ b/config/samples/openstack_v1alpha1_openstackfloatingip.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstackfloatingip
     app.kubernetes.io/instance: openstackfloatingip-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: fip-1
 spec:
   cloud: osp1

--- a/config/samples/openstack_v1alpha1_openstackimage.yaml
+++ b/config/samples/openstack_v1alpha1_openstackimage.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstackimage
     app.kubernetes.io/instance: openstackimage-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: fedora
 spec:
   cloud: osp1

--- a/config/samples/openstack_v1alpha1_openstacknetwork.yaml
+++ b/config/samples/openstack_v1alpha1_openstacknetwork.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstacknetwork
     app.kubernetes.io/instance: openstacknetwork-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: external
 spec:
   cloud: osp1
@@ -19,9 +19,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstacknetwork
     app.kubernetes.io/instance: openstacknetwork-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: network-1
 spec:
   cloud: osp1

--- a/config/samples/openstack_v1alpha1_openstacksecuritygroup.yaml
+++ b/config/samples/openstack_v1alpha1_openstacksecuritygroup.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstacksecuritygroup
     app.kubernetes.io/instance: openstacksecuritygroup-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: default
 spec:
   cloud: osp1
@@ -19,9 +19,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstacksecuritygroup
     app.kubernetes.io/instance: openstacksecuritygroup-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: workstation
 spec:
   cloud: osp1

--- a/config/samples/openstack_v1alpha1_openstacksecuritygrouprule.yaml
+++ b/config/samples/openstack_v1alpha1_openstacksecuritygrouprule.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstacksecuritygrouprule
     app.kubernetes.io/instance: openstacksecuritygrouprule-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: workstation-ssh-ipv4
 spec:
   cloud: osp1
@@ -24,9 +24,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstacksecuritygrouprule
     app.kubernetes.io/instance: openstacksecuritygrouprule-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: workstation-mosh-ipv4
 spec:
   cloud: osp1
@@ -44,9 +44,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstacksecuritygrouprule
     app.kubernetes.io/instance: openstacksecuritygrouprule-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: workstation-ssh-ipv6
 spec:
   cloud: osp1
@@ -64,9 +64,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstacksecuritygrouprule
     app.kubernetes.io/instance: openstacksecuritygrouprule-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: workstation-mosh-ipv6
 spec:
   cloud: osp1

--- a/config/samples/openstack_v1alpha1_openstackserver.yaml
+++ b/config/samples/openstack_v1alpha1_openstackserver.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstackserver
     app.kubernetes.io/instance: openstackserver-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: workstation
 spec:
   cloud: osp1

--- a/config/samples/openstack_v1alpha1_openstacksubnet.yaml
+++ b/config/samples/openstack_v1alpha1_openstacksubnet.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/name: openstacksubnet
     app.kubernetes.io/instance: openstacksubnet-sample
-    app.kubernetes.io/part-of: openstack-resource-controller
+    app.kubernetes.io/part-of: orc
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: openstack-resource-controller
+    app.kubernetes.io/created-by: orc
   name: network-1-subnet-1
 spec:
   cloud: osp1


### PR DESCRIPTION
The extended name (openstack-resource-controller) made some resource names overflow the 53-character limit.