### PR TITLE
container image: Prefix commit builds

### DIFF
--- a/.github/workflows/container_image.yaml
+++ b/.github/workflows/container_image.yaml
@@ -23,5 +23,5 @@ jobs:
         docker push ${{ env.image }}:main
         docker push ${{ env.image }}:latest
 
-        docker build -t ${{ env.image }}:${GITHUB_SHA::7} --label quay.expires-after=4w .
-        docker push ${{ env.image }}:${GITHUB_SHA::7}
+        docker build -t ${{ env.image }}:commit-${GITHUB_SHA::7} --label quay.expires-after=4w .
+        docker push ${{ env.image }}:commit-${GITHUB_SHA::7}


### PR DESCRIPTION
Prefix the commit SHA tag so that ephemeral builds are easier to spot in a list.